### PR TITLE
Bug/reset search results

### DIFF
--- a/src/APICalls.js
+++ b/src/APICalls.js
@@ -16,9 +16,8 @@ const checkForErrors = response => {
 export const fetchAllSongs = () => {
   return fetch('http://localhost:8080/songs')
     .then(checkForErrors)
-    .then(data => {
-      return data
-    })
+    // .then(data => {
+    //   return data
 }
 
 // export const fetchAllGenres = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -2,10 +2,8 @@ import React, { Component } from 'react';
 import { Route } from 'react-router-dom';
 import Navigation from './components/Navigation/Navigation';
 import SongLibrary from './components/SongLibrary/SongLibrary';
-import SearchBar from './components/SearchBar/SearchBar';
 import './App.css';
 import { fetchAllSongData } from './APICalls';
-import songData from './song-data';
 import { RiHeartAddLine } from 'react-icons/ri';
 import { MdRemoveCircle } from 'react-icons/md';
 
@@ -83,73 +81,5 @@ class App extends Component {
     )
   }
 }
-
-// class App extends Component {
-//   constructor() {
-//     super();
-//     this.state = {
-//       songBook: [],
-//       renderedSongs: [],
-//       mySongs: []
-//     }
-//   }
-
-//   componentDidMount() {
-//     fetchAllSongs()
-//       // .then(data => Promise.all(data))
-//       .then(data => {
-//         this.setState({ songBook: data })
-//         this.setState({renderedSongs: [...this.state.songBook]})
-//       })
-//   }
-
-//   addSong = (id) => {
-//    const songToAdd = this.state.songBook.find(song => {
-//     return song.id === id
-//     })
-//     this.setState({mySongs: [...this.state.mySongs, songToAdd]})
-//   }
-
-//   removeSong = (id) => {
-//     const editedSongList = this.state.mySongs.filter(song => {
-//       return song.id !== id
-//     })
-//     this.setState({mySongs: editedSongList})
-//   }
-
-//   searchForSongs = (searchQuery) => {
-//     let modifiedSearchQuery = searchQuery.toUpperCase();
-//     let matchingSongs = this.state.songBook.filter(song => song.title.toUpperCase().includes(modifiedSearchQuery)
-//     // || song.genres.toString().toUpperCase().includes(modifiedSearchQuery)
-//     || song.artist.toUpperCase().includes(modifiedSearchQuery)
-//     )
-//     this.setState({ renderedSongs: matchingSongs })
-//   }
-
-//   render () {
-//     return (
-//       <div className="App">
-//         <Route exact path="/">
-//           <section className="home-container"> 
-//             <h1 className="home-title">CarryOkay</h1>
-//             <p className="home-greeting">Hello friend 😬</p>
-//             <Navigation class="home-nav" />
-//           </section>
-//         </Route>
-//         <Route path="/mysongs">
-//           <h1>My Songs</h1>
-//           {this.state.mySongs.length && <SongLibrary songs={ this.state.mySongs } handleSong={this.removeSong} buttonIcon={<MdRemoveCircle className="handle-song-icon"/>}/>}
-//           <Navigation class="mysongs-nav" />
-//         </Route>
-//         <Route path="/songbook">
-//           <h1>SongBook</h1>
-//           <SearchBar searchForSongs={this.searchForSongs} />
-//          {this.state.songBook.length && <SongLibrary songs={ this.state.renderedSongs } handleSong={this.addSong} buttonIcon={<RiHeartAddLine className="handle-song-icon"/>}/>}
-//           <Navigation class="songbook-nav" />
-//         </Route>
-//       </div>
-//     )
-//   }
-// }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -15,17 +15,17 @@ class App extends Component {
     super();
     this.state = {
       songBook: [],
-      renderedSongs: [],
+      // renderedSongs: [],
       mySongs: []
     }
   }
 
   componentDidMount() {
     fetchAllSongs()
-      .then(data => Promise.all(data))
+      // .then(data => Promise.all(data))
       .then(data => {
         this.setState({ songBook: data })
-        this.setState({renderedSongs: [...this.state.songBook]})
+        // this.setState({renderedSongs: [...this.state.songBook]})
       })
   }
 
@@ -43,16 +43,17 @@ class App extends Component {
     this.setState({mySongs: editedSongList})
   }
 
-  searchForSongs = (searchQuery) => {
-    let modifiedSearchQuery = searchQuery.toUpperCase();
-    let matchingSongs = this.state.songBook.filter(song => song.title.toUpperCase().includes(modifiedSearchQuery)
-    // || song.genres.toString().toUpperCase().includes(modifiedSearchQuery)
-    || song.artist.toUpperCase().includes(modifiedSearchQuery)
-    )
-    this.setState({ renderedSongs: matchingSongs })
-  }
+  // searchForSongs = (searchQuery) => {
+  //   let modifiedSearchQuery = searchQuery.toUpperCase();
+  //   let matchingSongs = this.state.songBook.filter(song => song.title.toUpperCase().includes(modifiedSearchQuery)
+  //   // || song.genres.toString().toUpperCase().includes(modifiedSearchQuery)
+  //   || song.artist.toUpperCase().includes(modifiedSearchQuery)
+  //   )
+  //   this.setState({ renderedSongs: matchingSongs })
+  // }
 
   render () {
+    console.log(this.state)
     return (
       <div className="App">
         <Route exact path="/">
@@ -69,13 +70,80 @@ class App extends Component {
         </Route>
         <Route path="/songbook">
           <h1>SongBook</h1>
-          <SearchBar searchForSongs={this.searchForSongs} />
-         {this.state.songBook.length && <SongLibrary songs={ this.state.renderedSongs } handleSong={this.addSong} buttonIcon={<RiHeartAddLine className="handle-song-icon"/>}/>}
+         {this.state.songBook.length && <SongLibrary songs={ this.state.songBook } handleSong={this.addSong} buttonIcon={<RiHeartAddLine className="handle-song-icon"/>}/>}
           <Navigation class="songbook-nav" />
         </Route>
       </div>
     )
   }
 }
+
+// class App extends Component {
+//   constructor() {
+//     super();
+//     this.state = {
+//       songBook: [],
+//       renderedSongs: [],
+//       mySongs: []
+//     }
+//   }
+
+//   componentDidMount() {
+//     fetchAllSongs()
+//       // .then(data => Promise.all(data))
+//       .then(data => {
+//         this.setState({ songBook: data })
+//         this.setState({renderedSongs: [...this.state.songBook]})
+//       })
+//   }
+
+//   addSong = (id) => {
+//    const songToAdd = this.state.songBook.find(song => {
+//     return song.id === id
+//     })
+//     this.setState({mySongs: [...this.state.mySongs, songToAdd]})
+//   }
+
+//   removeSong = (id) => {
+//     const editedSongList = this.state.mySongs.filter(song => {
+//       return song.id !== id
+//     })
+//     this.setState({mySongs: editedSongList})
+//   }
+
+//   searchForSongs = (searchQuery) => {
+//     let modifiedSearchQuery = searchQuery.toUpperCase();
+//     let matchingSongs = this.state.songBook.filter(song => song.title.toUpperCase().includes(modifiedSearchQuery)
+//     // || song.genres.toString().toUpperCase().includes(modifiedSearchQuery)
+//     || song.artist.toUpperCase().includes(modifiedSearchQuery)
+//     )
+//     this.setState({ renderedSongs: matchingSongs })
+//   }
+
+//   render () {
+//     return (
+//       <div className="App">
+//         <Route exact path="/">
+//           <section className="home-container"> 
+//             <h1 className="home-title">CarryOkay</h1>
+//             <p className="home-greeting">Hello friend 😬</p>
+//             <Navigation class="home-nav" />
+//           </section>
+//         </Route>
+//         <Route path="/mysongs">
+//           <h1>My Songs</h1>
+//           {this.state.mySongs.length && <SongLibrary songs={ this.state.mySongs } handleSong={this.removeSong} buttonIcon={<MdRemoveCircle className="handle-song-icon"/>}/>}
+//           <Navigation class="mysongs-nav" />
+//         </Route>
+//         <Route path="/songbook">
+//           <h1>SongBook</h1>
+//           <SearchBar searchForSongs={this.searchForSongs} />
+//          {this.state.songBook.length && <SongLibrary songs={ this.state.renderedSongs } handleSong={this.addSong} buttonIcon={<RiHeartAddLine className="handle-song-icon"/>}/>}
+//           <Navigation class="songbook-nav" />
+//         </Route>
+//       </div>
+//     )
+//   }
+// }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ class App extends Component {
     super();
     this.state = {
       songBook: [],
-      // renderedSongs: [],
       mySongs: []
     }
   }
@@ -42,15 +41,6 @@ class App extends Component {
     })
     this.setState({mySongs: editedSongList})
   }
-
-  // searchForSongs = (searchQuery) => {
-  //   let modifiedSearchQuery = searchQuery.toUpperCase();
-  //   let matchingSongs = this.state.songBook.filter(song => song.title.toUpperCase().includes(modifiedSearchQuery)
-  //   // || song.genres.toString().toUpperCase().includes(modifiedSearchQuery)
-  //   || song.artist.toUpperCase().includes(modifiedSearchQuery)
-  //   )
-  //   this.setState({ renderedSongs: matchingSongs })
-  // }
 
   render () {
     console.log(this.state)

--- a/src/components/SongLibrary/SongLibrary.js
+++ b/src/components/SongLibrary/SongLibrary.js
@@ -49,7 +49,6 @@ class SongLibrary extends Component {
   }
 
   render() {
-    console.log(this.state)
     const allSongs = this.createSongCards()
     return (
       <div className='library'>
@@ -59,27 +58,5 @@ class SongLibrary extends Component {
     )
   }
 }
-
-// const SongLibrary = ({ songs, handleSong, buttonIcon }) => {
-//   const allSongs = songs.map(song => {
-//     return (
-//       <SongCard
-//       key={ song.id }
-//       id={ song.id }
-//       title={ song.title_title }
-//       artist={ song.artist }
-//       genres={ song.genres }
-//       album_cover={ song.album_cover }
-//       handleSong={ handleSong }
-//       buttonIcon={ buttonIcon }
-//       />
-//     );
-//   });
-//   return (
-//     <div className='library'>
-//       {allSongs}
-//     </div>
-//   );
-// };
 
 export default SongLibrary;

--- a/src/components/SongLibrary/SongLibrary.js
+++ b/src/components/SongLibrary/SongLibrary.js
@@ -1,27 +1,85 @@
-import React from 'react';
+import { React, Component } from 'react';
 import SongCard from '../SongCard/SongCard';
 import '../SongLibrary/SongLibrary.css'
+import SearchBar from "../SearchBar/SearchBar";
 
-const SongLibrary = ({ songs, handleSong, buttonIcon }) => {
-  const allSongs = songs.map(song => {
+
+
+class SongLibrary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { 
+      renderedSongs: []    
+    }
+  }
+
+ 
+   searchForSongs = (searchQuery) => {
+    let modifiedSearchQuery = searchQuery.toUpperCase();
+    let matchingSongs = this.props.songs.filter(song => song.title.toUpperCase().includes(modifiedSearchQuery)
+    // || song.genres.toString().toUpperCase().includes(modifiedSearchQuery)
+    || song.artist.toUpperCase().includes(modifiedSearchQuery)
+    )
+    this.setState({ renderedSongs: matchingSongs })
+  }
+
+  createSongCards = () => {
+    let songList; 
+    if( this.state.renderedSongs.length) {
+      songList = this.state.renderedSongs
+    } else {
+      songList = this.props.songs
+    }
+    const allSongs = songList.map(song => {
+      return (
+        <SongCard
+        key={ song.id }
+        id={ song.id }
+        title={ song.title_title }
+        artist={ song.artist }
+        genres={ song.genres }
+        album_cover={ song.album_cover }
+        handleSong={ this.props.handleSong }
+        buttonIcon={ this.props.buttonIcon }
+        />
+      );
+    });
+   return allSongs
+
+  }
+
+  render() {
+    console.log(this.state)
+    const allSongs = this.createSongCards()
     return (
-      <SongCard
-      key={ song.id }
-      id={ song.id }
-      title={ song.title_title }
-      artist={ song.artist }
-      genres={ song.genres }
-      album_cover={ song.album_cover }
-      handleSong={ handleSong }
-      buttonIcon={ buttonIcon }
-      />
-    );
-  });
-  return (
-    <div className='library'>
-      {allSongs}
-    </div>
-  );
-};
+      <div className='library'>
+        <SearchBar searchForSongs={this.searchForSongs} />
+         {allSongs}
+      </div>
+    )
+  }
+}
+
+// const SongLibrary = ({ songs, handleSong, buttonIcon }) => {
+//   const allSongs = songs.map(song => {
+//     return (
+//       <SongCard
+//       key={ song.id }
+//       id={ song.id }
+//       title={ song.title_title }
+//       artist={ song.artist }
+//       genres={ song.genres }
+//       album_cover={ song.album_cover }
+//       handleSong={ handleSong }
+//       buttonIcon={ buttonIcon }
+//       />
+//     );
+//   });
+//   return (
+//     <div className='library'>
+//       {allSongs}
+//     </div>
+//   );
+// };
 
 export default SongLibrary;

--- a/src/components/SongLibrary/SongLibrary.js
+++ b/src/components/SongLibrary/SongLibrary.js
@@ -51,10 +51,12 @@ class SongLibrary extends Component {
   render() {
     const allSongs = this.createSongCards()
     return (
-      <div className='library'>
+      <>
         <SearchBar searchForSongs={this.searchForSongs} />
-         {allSongs}
-      </div>
+        <div className='library'>
+          {allSongs}
+        </div>
+      </>
     )
   }
 }


### PR DESCRIPTION
## What does this PR do (summary of changes)?
 - This addresses the issue we were having with the search feature
 - Searching was working but when a user switched to the "My Songs" and then switched back to "Songbook" the songbook was only able to  display the last songs that were searched and would not reset. 
 - Now if a user navigates away from the searched songs, and navigates back, the songbook is refreshed to display all songs so a use can start a new search
## How should it be tested?
 - Fetch down the branch and test out searching, then navigating between the two views we have. 
 - After searching, then navigating, away and back to the song book, you should see a full list of songs
## Future Iterations:
 - Add a "clear search" option for users to clear the search if they haven't navigated away
