### PR TITLE
Feature/remove add btn onclick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "karaoke-stretch",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.11.10",
@@ -19,6 +18,7 @@
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
+        "sass": "^1.32.8",
         "web-vitals": "^1.1.1"
       },
       "devDependencies": {
@@ -4895,7 +4895,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5431,7 +5430,6 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
       "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-      "optional": true,
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -10806,7 +10804,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "optional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -18071,7 +18068,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
       "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "optional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -19082,6 +19078,20 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
       "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
+    },
+    "node_modules/sass": {
+      "version": "1.32.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+      "dependencies": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
     },
     "node_modules/sass-graph": {
       "version": "2.2.5",
@@ -27461,8 +27471,7 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "optional": true
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -27900,7 +27909,6 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
       "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-      "optional": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -32141,7 +32149,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "optional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -37734,7 +37741,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
       "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -38528,6 +38534,14 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
       "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
+    },
+    "sass": {
+      "version": "1.32.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
     },
     "sass-graph": {
       "version": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "sass": "^1.32.8",
     "web-vitals": "^1.1.1"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,7 @@ class App extends Component {
   }
 
   render () {
-    console.log(this.state)
+    // console.log(this.state)
     return (
       <div className="App">
         <Route exact path="/">
@@ -70,12 +70,26 @@ class App extends Component {
         <Route path="/mysongs">
           <h1>My Songs</h1>
           <Navigation class="mysongs-nav" />
-          {!!this.state.mySongs.length && <SongLibrary songs={ this.state.mySongs } handleSong={this.removeSong} buttonIcon={<MdRemoveCircle className="handle-song-icon"/>}/>}
+          {!!this.state.mySongs.length && 
+          <SongLibrary 
+          songs={ this.state.mySongs } 
+          mySongs={this.state.mySongs }
+          handleSong={this.removeSong} 
+          buttonIcon={<MdRemoveCircle 
+          className="handle-song-icon"/>}
+          />}
         </Route>
         <Route path="/songbook">
           <h1>SongBook</h1>
           <Navigation class="songbook-nav" />
-         {!!this.state.songBook.length && <SongLibrary songs={ this.state.songBook } handleSong={this.addSong} buttonIcon={<RiHeartAddLine className="handle-song-icon"/>}/>}
+          {!!this.state.songBook.length && 
+          <SongLibrary 
+          songs={ this.state.songBook } 
+          mySongs={this.state.mySongs}
+          handleSong={this.addSong} 
+          buttonIcon={<RiHeartAddLine 
+          className="handle-song-icon"/>}
+          />}
         </Route>
       </div>
     )

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Route } from 'react-router-dom';
 import Navigation from './components/Navigation/Navigation';
 import SongLibrary from './components/SongLibrary/SongLibrary';
+import MySongLibrary from './components/MySongLibrary/MySongLibrary';
 import './App.scss';
 import { fetchAllSongData } from './APICalls';
 import { RiHeartAddLine } from 'react-icons/ri';
@@ -71,12 +72,11 @@ class App extends Component {
           <h1>My Songs</h1>
           <Navigation class="mysongs-nav" />
           {!!this.state.mySongs.length && 
-          <SongLibrary 
+          <MySongLibrary
           songs={ this.state.mySongs } 
           mySongs={this.state.mySongs }
           handleSong={this.removeSong} 
-          buttonIcon={<MdRemoveCircle 
-          className="handle-song-icon"/>}
+          buttonIcon={<MdRemoveCircle className="handle-song-icon"/>}
           />}
         </Route>
         <Route path="/songbook">
@@ -87,8 +87,7 @@ class App extends Component {
           songs={ this.state.songBook } 
           mySongs={this.state.mySongs}
           handleSong={this.addSong} 
-          buttonIcon={<RiHeartAddLine 
-          className="handle-song-icon"/>}
+          buttonIcon={<RiHeartAddLine className="handle-song-icon"/>}
           />}
         </Route>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Route } from 'react-router-dom';
 import Navigation from './components/Navigation/Navigation';
 import SongLibrary from './components/SongLibrary/SongLibrary';
-import MySongLibrary from './components/MySongLibrary/MySongLibrary';
+import MySongLibrary from './components/mySongLibrary/MySongLibrary';
 import './App.scss';
 import { fetchAllSongData } from './APICalls';
 import { RiHeartAddLine } from 'react-icons/ri';

--- a/src/App.js
+++ b/src/App.js
@@ -88,7 +88,7 @@ class App extends Component {
           songs={ this.state.songBook } 
           mySongs={this.state.mySongs}
           handleSong={this.addSong} 
-          buttonIcon={[<RiHeartAddLine className="handle-song-icon"/> , <FaHeart className="handle-song-icon"/>]}
+          buttonIcon={[<RiHeartAddLine className="handle-song-icon"/> , <FaHeart className="heart-icon"/>]}
           />}
         </Route>
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import './App.scss';
 import { fetchAllSongData } from './APICalls';
 import { RiHeartAddLine } from 'react-icons/ri';
 import { MdRemoveCircle } from 'react-icons/md';
+import { FaHeart } from 'react-icons/fa';
 
 
 class App extends Component {
@@ -76,7 +77,7 @@ class App extends Component {
           songs={ this.state.mySongs } 
           mySongs={this.state.mySongs }
           handleSong={this.removeSong} 
-          buttonIcon={<MdRemoveCircle className="handle-song-icon"/>}
+          buttonIcon={[<MdRemoveCircle className="handle-song-icon"/>]}
           />}
         </Route>
         <Route path="/songbook">
@@ -87,7 +88,7 @@ class App extends Component {
           songs={ this.state.songBook } 
           mySongs={this.state.mySongs}
           handleSong={this.addSong} 
-          buttonIcon={<RiHeartAddLine className="handle-song-icon"/>}
+          buttonIcon={[<RiHeartAddLine className="handle-song-icon"/> , <FaHeart className="handle-song-icon"/>]}
           />}
         </Route>
       </div>

--- a/src/App.scss
+++ b/src/App.scss
@@ -45,3 +45,9 @@ body {
 .handle-song-icon:hover {
   color: rgb(164, 12, 103);
 }
+
+.heart-icon {
+  color: rgb(179, 10, 10);
+  width: 100%;
+  height: 100%; 
+}

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import './SearchBar.css';
+import './SearchBar.scss';
 
 class SearchBar extends Component {
   constructor() {

--- a/src/components/SongCard/SongCard.js
+++ b/src/components/SongCard/SongCard.js
@@ -2,14 +2,14 @@ import React from 'react';
 import '../SongCard/SongCard.scss'
 
 
-const SongCard = ({ id, title, artist, genres, album_cover, handleSong, buttonIcon }) => {
+const SongCard = ({ id, title, artist, genres, album_cover, handleSong, buttonIcon, isActive }) => {
 
   const listItems = genres.map(genre => {
     return (
       <li className="genre">{ genre }</li>
     );
   });
-
+  console.log(isActive)
   return (
     <div className='song-card'>
       <img src={ album_cover }/>
@@ -20,7 +20,7 @@ const SongCard = ({ id, title, artist, genres, album_cover, handleSong, buttonIc
           { listItems }
         </ul>
       </article>
-      <button className="handle-song-btn" id={id} onClick={() => handleSong(id)}>{ buttonIcon }</button>
+      <button className={isActive ? "handle-song-btn" : "hidden" } id={id} onClick={() => handleSong(id)}>{ buttonIcon }</button>
     </div>
   );
 };

--- a/src/components/SongCard/SongCard.js
+++ b/src/components/SongCard/SongCard.js
@@ -9,7 +9,7 @@ const SongCard = ({ id, title, artist, genres, album_cover, handleSong, buttonIc
       <li className="genre">{ genre }</li>
     );
   });
-  console.log(isActive)
+  
   return (
     <div className='song-card'>
       <img src={ album_cover }/>

--- a/src/components/SongCard/SongCard.js
+++ b/src/components/SongCard/SongCard.js
@@ -9,7 +9,7 @@ const SongCard = ({ id, title, artist, genres, album_cover, handleSong, buttonIc
       <li className="genre">{ genre }</li>
     );
   });
-  
+
   return (
     <div className='song-card'>
       <img src={ album_cover }/>
@@ -20,7 +20,7 @@ const SongCard = ({ id, title, artist, genres, album_cover, handleSong, buttonIc
           { listItems }
         </ul>
       </article>
-      <button className={isActive ? "handle-song-btn" : "hidden" } id={id} onClick={() => handleSong(id)}>{ buttonIcon }</button>
+      <button className={"handle-song-btn"} disabled={!isActive} id={id} onClick={() => handleSong(id)}>{ isActive ? buttonIcon[0] : buttonIcon[1]}</button>
     </div>
   );
 };

--- a/src/components/SongCard/SongCard.scss
+++ b/src/components/SongCard/SongCard.scss
@@ -37,12 +37,12 @@
   position: absolute;
   right: 5px;
   top: 42.5%;
-  /* margin: 0 auto;  */
   min-width: 45px;
   background: none;
   cursor: pointer;
   border: none;
 }
+
 
 .hidden {
   display: none;

--- a/src/components/SongCard/SongCard.scss
+++ b/src/components/SongCard/SongCard.scss
@@ -44,3 +44,7 @@
   border: none;
 }
 
+.hidden {
+  display: none;
+}
+

--- a/src/components/SongLibrary/SongLibrary.js
+++ b/src/components/SongLibrary/SongLibrary.js
@@ -31,13 +31,10 @@ class SongLibrary extends Component {
       songList = this.props.songs
     }
     const allSongs = songList.map(song => {
-      let isActive;
+      let isActive = true;
       if(this.props.mySongs.includes(song)) {
         isActive = false; 
-      } else {
-        isActive = true; 
-      }
-      
+      } 
       return (
         <SongCard
         key={ song.id }

--- a/src/components/SongLibrary/SongLibrary.js
+++ b/src/components/SongLibrary/SongLibrary.js
@@ -31,16 +31,24 @@ class SongLibrary extends Component {
       songList = this.props.songs
     }
     const allSongs = songList.map(song => {
+      let isActive;
+      if(this.props.mySongs.includes(song)) {
+        isActive = false; 
+      } else {
+        isActive = true; 
+      }
+      
       return (
         <SongCard
         key={ song.id }
         id={ song.id }
-        title={ song.title_title }
+        title={ song.title }
         artist={ song.artist }
         genres={ song.genres }
         album_cover={ song.album_cover }
         handleSong={ this.props.handleSong }
         buttonIcon={ this.props.buttonIcon }
+        isActive={isActive}
         />
       );
     });

--- a/src/components/mySongLibrary/MySongLibrary.js
+++ b/src/components/mySongLibrary/MySongLibrary.js
@@ -1,0 +1,26 @@
+import React from "react";
+
+const MySongLibrary = (props) => {
+  const mySongList = props.songs.map(song => {
+    return (
+      <SongCard
+      key={ song.id }
+      id={ song.id }
+      title={ song.title }
+      artist={ song.artist }
+      genres={ song.genres }
+      album_cover={ song.album_cover }
+      handleSong={ this.props.handleSong }
+      buttonIcon={ this.props.buttonIcon }
+      />
+    );
+  })
+  return (
+    <section>
+      {mySongList}
+    </section>
+  )
+  
+}
+
+export default MySongLibrary; 

--- a/src/components/mySongLibrary/MySongLibrary.js
+++ b/src/components/mySongLibrary/MySongLibrary.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import SongCard from '../SongCard/SongCard';
+import './MySongLibrary.scss';
 
 const MySongLibrary = (props) => {
   const mySongList = props.songs.map(song => {
@@ -18,7 +19,7 @@ const MySongLibrary = (props) => {
     );
   })
   return (
-    <section>
+    <section className="my-library">
       {mySongList}
     </section>
   )

--- a/src/components/mySongLibrary/MySongLibrary.js
+++ b/src/components/mySongLibrary/MySongLibrary.js
@@ -14,7 +14,7 @@ const MySongLibrary = (props) => {
       album_cover={ song.album_cover }
       handleSong={ props.handleSong }
       buttonIcon={ props.buttonIcon }
-      isActive={true}
+      isActive={ true }
       />
     );
   })

--- a/src/components/mySongLibrary/MySongLibrary.js
+++ b/src/components/mySongLibrary/MySongLibrary.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React from 'react';
+import SongCard from '../SongCard/SongCard';
 
 const MySongLibrary = (props) => {
   const mySongList = props.songs.map(song => {
@@ -10,8 +11,9 @@ const MySongLibrary = (props) => {
       artist={ song.artist }
       genres={ song.genres }
       album_cover={ song.album_cover }
-      handleSong={ this.props.handleSong }
-      buttonIcon={ this.props.buttonIcon }
+      handleSong={ props.handleSong }
+      buttonIcon={ props.buttonIcon }
+      isActive={true}
       />
     );
   })

--- a/src/components/mySongLibrary/MySongLibrary.scss
+++ b/src/components/mySongLibrary/MySongLibrary.scss
@@ -1,0 +1,19 @@
+.my-library {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(2, minmax( 260px, 1fr));
+  grid-template-rows: auto;
+  gap: 10px;
+  justify-items: stretch;
+  align-items: stretch
+}
+
+.my-library > * {
+  grid-column: span 1;
+}
+
+@media (max-width: 1025px) {
+  .my-library {
+    grid-template-columns: minmax(260px, 1fr);
+  }
+}


### PR DESCRIPTION
## What does this PR do (summary of changes)?
 - This adds functionality for when a user adds a song to their library, the add button will disappear and be replaced by a heart icon indicating that it was added to the library successfully
 - The heart icon is disabled so the user cannot add duplicate songs
 - The "my songs" view needed it's own container to be able to render the buttons dynamically
    - By creating a container component for the user's songs, I was able to pass down props relating the the button to keep the remove icon from disappearing and use logic in the "songbook" view to remove the button on click
    
## How should it be tested?
 - Fetch down the branch and test out the application by adding multiple songs, check the user's song library to see that the songs were added and the remove icon is visible. The user should be able to remove a song 
 - When a user removes a song from their library, the song should now show the add song icon again in the main song library
## Future Iterations:
 - A message to go with the heart icon
 - An animation transition when the user adds the song
