### PR TITLE
feature/clear-search-btn

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -29,7 +29,6 @@ class SearchBar extends Component {
   }
 
   render () {
-    console.log(this.state)
     return (
       <form>
         <input

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -23,7 +23,13 @@ class SearchBar extends Component {
     this.clearInputs();
   }
 
+  clearSearch = (event) => {
+    event.preventDefault();
+    this.props.searchForSongs(''); 
+  }
+
   render () {
+    console.log(this.state)
     return (
       <form>
         <input
@@ -35,6 +41,7 @@ class SearchBar extends Component {
           onChange={ event => this.handleChange(event) }
         />
         <button onClick={ event => this.search(event) }>Search!</button>
+        <button onClick={event => this.clearSearch(event)}>Clear Search</button>
 
       </form>
     )


### PR DESCRIPTION
## What does this PR do (summary of changes)?
 - This adds a clear search button for users to increase UX
 - When a user clicks on the clear search button from the songbook view, all songs will display
 - If text is in the search bar and the clear search button is clicked, all songs will display
## How should it be tested?
 - Fetch down the branch and try out a few searches, click the clear search button, all songs should display
 - Type text into the search bar and then hit the clear search button, all songs should display
## Future Iterations:
 - Buttons need to be styled for UX
