### PR TITLE
Change width property to address styling bug on icons

### DIFF
--- a/src/components/SongCard/SongCard.scss
+++ b/src/components/SongCard/SongCard.scss
@@ -37,7 +37,7 @@
   position: absolute;
   right: 5px;
   top: 42.5%;
-  min-width: 45px;
+  width: 45px;
   background: none;
   cursor: pointer;
   border: none;
@@ -47,4 +47,3 @@
 .hidden {
   display: none;
 }
-


### PR DESCRIPTION
## What does this PR do (summary of changes)?
 -  Changes the width property on song card icon / button to fix styling bug on my end (so weird)
 
## How should it be tested?
 - The icons should be of reasonable size
 
## Future Iterations:
 - NA
